### PR TITLE
Small fixes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* linguist-vendored
+*.py linguist-vendored=false

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -38,9 +38,7 @@ jobs:
         
       - name: Test with unittest
         run: |
-          python -m unittest tests/integration/test_segmentation.py
-        #run: |
-        #  python -m unittest tests/**/test_*.py
+          python -m unittest tests/**/test_*.py
           
       #- name: Test coverage analysis
       #  run: |

--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ PV Hawk
 
 **Documentation**: https://lukasbommes.github.io/PV-Hawk/
 
-**Code**: https://lukasbommes.github.io/PV-Hawk/
+**Code**: https://github.com/LukasBommes/PV-Hawk
 
 PV Hawk is a computer vision pipeline for the **automated inspection** of large-scale **photovoltaic (PV) plants** by means of **thermal infrared (IR) videos** acquired by a drone.
 

--- a/extractor/mapping/prepare_opensfm.py
+++ b/extractor/mapping/prepare_opensfm.py
@@ -235,7 +235,7 @@ def run(cluster, frames_root, calibration_root, output_dir, opensfm_settings,
 
     frame_names = []
     for selected_frame in selected_frames:
-        frame, _, frame_name, _ = cap.get_frame(selected_frame, preprocess=True, undistort=True, equalize_hist=True)  # Note: undistort should probably be set to False
+        frame, _, frame_name, _ = cap.get_frame(selected_frame, preprocess=True, undistort=False, equalize_hist=True)  # Note: undistort should probably be set to False
         frame_names.append(frame_name)
         frame = cv2.cvtColor(frame, cv2.COLOR_GRAY2BGR)
         videowriter.write(frame)


### PR DESCRIPTION
This PR fixes some minor mistakes in the docs and changes a setting in `prepare_opensfm.py` so that original (radially distorted) video frames fed into OpenSfM instead of undistorted frames as previously.