### PR TITLE
fix mount problem and updated paper citations

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,13 +19,13 @@ After recording an IR video of a PV plant, individual video frames and the corre
 
 PV Hawk implements the method described briefly in `How PV Hawk Works <https://lukasbommes.github.io/PV-Hawk/method.html>`_. For more details see our journal papers:
 
-[1] L. Bommes, T. Pickel, C. Buerhop-Lutz, J. Hauch, C. Brabec, I. Peters, ”Georeferencing of photovoltaic modules from aerial infrared videos using structure-from-motion,” Progress in Photovoltaics: Research and Applications, 2022 (submitted, acceptance pending).
+[1] L. Bommes, T. Pickel, C. Buerhop-Lutz, J. Hauch, C. Brabec, and I. Peters, “Georeferencing of photovoltaic modules from aerial infrared videos using structure-from-motion,” Progress in Photovoltaics: Research and Applications, vol. 30, no. 9, pp. 1122–1135, 2022. `DOI 10.1002/pip.3564 <https://doi.org/10.1002/pip.3564>`_. [`ArXiv 2204.02733 <https://arxiv.org/abs/2204.02733>`_]
 
-[2] L. Bommes, T. Pickel, C. Buerhop-Lutz, J. Hauch, C. Brabec, I. Peters, ”Computer vision tool for detection, mapping, and fault classification of photovoltaics modules in aerial IR videos,” Progress in Photovoltaics: Research and Applications, 2021. [`Wiley PIP <https://onlinelibrary.wiley.com/doi/10.1002/pip.3448>`_, `ArXiv <https://arxiv.org/abs/2106.07314>`_]
+[2] L. Bommes, T. Pickel, C. Buerhop-Lutz, J. Hauch, C. Brabec, and I. Peters, “Computer vision tool for detection, mapping, and fault classification of photovoltaics modules in aerial IR videos,” Progress in Photovoltaics: Research and Applications, vol. 29, no. 12, pp. 1236–1251, 2021. `DOI 10.1002/pip.3448 <https://doi.org/10.1002/pip.3448>`_. `ArXiv 2106.07314 <https://arxiv.org/abs/2106.07314>`_]
 
 You may also find our related work on PV module defect detection interesting, which uses a dataset created with PV Hawk:
 
-[3] L. Bommes, M. Hoffmann, C. Buerhop-Lutz, T. Pickel, J. Hauch, C. Brabec, A. Maier, I. Peters, ”Anomaly detection in IR images of PV modules using supervised contrastive learning,” Progress in Photovoltaics: Research and Applications, 2022 (accepted for publication). [`ArXiv <https://arxiv.org/abs/2112.02922>`_]
+[3] L. Bommes, M. Hoffmann, C. Buerhop-Lutz, T. Pickel, J. Hauch, C. Brabec, A. Maier, and I. Peters, “Anomaly detection in IR images of PV modules using supervised contrastive learning,” Progress in Photovoltaics: Research and Applications, vol. 30, no. 6, pp. 597–614, 2022. `DOI 10.1002/pip.3518 <https://doi.org/10.1002/pip.3518>`_. [`ArXiv 2112.02922 <https://arxiv.org/abs/2112.02922>`_]
 
 PV Hawk is a command line tool written in Python. It is free of charge, open-source, and MIT licensed.
 

--- a/docs/source/about.rst
+++ b/docs/source/about.rst
@@ -42,38 +42,49 @@ Citation
 
 PV Hawk is based on the following journal papers. If you use PV Hawk in your own research please consider citing us.
 
-[1] L. Bommes, T. Pickel, C. Buerhop-Lutz, J. Hauch, C. Brabec, I. Peters, ”Georeferencing of photovoltaic modules from aerial infrared videos using structure-from-motion,” Progress in Photovoltaics: Research and Applications, 2022 (submitted, acceptance pending).
+[1] L. Bommes, T. Pickel, C. Buerhop-Lutz, J. Hauch, C. Brabec, and I. Peters, “Georeferencing of photovoltaic modules from aerial infrared videos using structure-from-motion,” Progress in Photovoltaics: Research and Applications, vol. 30, no. 9, pp. 1122–1135, 2022. `DOI 10.1002/pip.3564 <https://doi.org/10.1002/pip.3564>`_. [`ArXiv 2204.02733 <https://arxiv.org/abs/2204.02733>`_]
 
 .. code-block:: text
 
-	[paper not yet published]
+	@article{Bommes.2022b,
+	    author = {Bommes, Lukas and Pickel, Tobias and Buerhop-Lutz, Claudia and Hauch, Jens and Brabec, Christoph and Peters, Ian Marius},
+	    title = {Georeferencing of photovoltaic modules from aerial infrared videos using structure-from-motion},
+	    journal = {Progress in Photovoltaics: Research and Applications},
+	    year = {2022},
+	    volume = {30},
+	    number = {9},
+	    pages = {1122--1135},
+	    doi = {10.1002/pip.3564}}
 
 
-[2] L. Bommes, T. Pickel, C. Buerhop-Lutz, J. Hauch, C. Brabec, I. Peters, ”Computer vision tool for detection, mapping, and fault classification of photovoltaics modules in aerial IR videos,” Progress in Photovoltaics: Research and Applications, 2021. [`Wiley PIP <https://onlinelibrary.wiley.com/doi/10.1002/pip.3448>`_, `ArXiv <https://arxiv.org/abs/2106.07314>`_]
+[2] L. Bommes, T. Pickel, C. Buerhop-Lutz, J. Hauch, C. Brabec, and I. Peters, “Computer vision tool for detection, mapping, and fault classification of photovoltaics modules in aerial IR videos,” Progress in Photovoltaics: Research and Applications, vol. 29, no. 12, pp. 1236–1251, 2021. `DOI 10.1002/pip.3448 <https://doi.org/10.1002/pip.3448>`_. [`ArXiv 2106.07314 <https://arxiv.org/abs/2106.07314>`_]
 
 .. code-block:: text
-
+	  
 	@article{Bommes.2021,
-	  author  = {Bommes, Lukas and Pickel, Tobias and Buerhop-Lutz, Claudia and Hauch, Jens and Brabec, Christoph and Peters, Ian Marius},
-	  title   = {Computer vision tool for detection, mapping, and fault classification of photovoltaics modules in aerial {IR} videos},
-	  journal = {Progress in Photovoltaics: Research and Applications},
-	  volume  = {29},
-	  number  = {12},
-	  pages   = {1236--1251},
-	  year    = {2021}}
+	    author = {Bommes, Lukas and Pickel, Tobias and Buerhop-Lutz, Claudia and Hauch, Jens and Brabec, Christoph and Peters, Ian Marius},
+	    title = {Computer vision tool for detection, mapping, and fault classification of photovoltaics modules in aerial {IR} videos},
+	    journal = {Progress in Photovoltaics: Research and Applications},
+	    year = {2021},
+	    volume = {29},
+	    number = {12},
+	    pages = {1236--1251},
+	    doi = {10.1002/pip.3448}}
 
 	  
-[3] L. Bommes, M. Hoffmann, C. Buerhop-Lutz, T. Pickel, J. Hauch, C. Brabec, A. Maier, I. Peters, ”Anomaly detection in IR images of PV modules using supervised contrastive learning,” Progress in Photovoltaics: Research and Applications, 2022 (accepted for publication). [`ArXiv <https://arxiv.org/abs/2112.02922>`_]
+[3] L. Bommes, M. Hoffmann, C. Buerhop-Lutz, T. Pickel, J. Hauch, C. Brabec, A. Maier, and I. Peters, “Anomaly detection in IR images of PV modules using supervised contrastive learning,” Progress in Photovoltaics: Research and Applications, vol. 30, no. 6, pp. 597–614, 2022. `DOI 10.1002/pip.3518 <https://doi.org/10.1002/pip.3518>`_. [`ArXiv 2112.02922 <https://arxiv.org/abs/2112.02922>`_]
 
 .. code-block:: text
+	
+	@article{Bommes.2022,
+	    author = {Bommes, Lukas and Hoffmann, Mathis and Buerhop-Lutz, Claudia and Pickel, Tobias and Hauch, Jens and Brabec, Christoph and Maier, Andreas and Peters, Ian Marius},
+	    title = {Anomaly detection in {IR} images of {PV} modules using supervised contrastive learning},
+	    journal = {Progress in Photovoltaics: Research and Applications},
+	    year = {2022},
+	    volume = {30},
+	    number = {6},
+	    pages = {597--614},
+	    doi = {10.1002/pip.3518}}
 
-	@misc{Bommes.2021b,
-	  author={Bommes, Lukas and Hoffmann, Mathis and Buerhop-Lutz, Claudia and Pickel, Tobias and Hauch, Jens and Brabec, Christoph and Maier, Andreas and Peters, Ian Marius},
-	  title={Anomaly Detection in IR Images of PV Modules using Supervised Contrastive Learning}, 
-	  year={2021},
-	  eprint={2112.02922},
-	  archivePrefix={arXiv},
-	  primaryClass={cs.CV}
-	}
 
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -50,15 +50,16 @@ PV Hawk comes with some test cases, which you can run to test whether the instal
   xhost +
 
 .. code-block:: console
-
+    
   sudo docker run -it \
     --ipc=host \
     --env="DISPLAY" \
     --gpus=all \
-    -v /tmp/.X11-unix:/tmp/.X11-unix:rw \
-    -v "$(pwd)":/pvextractor \
+    --mount type=bind,src=/tmp/.X11-unix,dst=/tmp/.X11-unix:rw \
+    --mount type=bind,src="$(pwd)",dst=/pvextractor \
+    --mount type=volume,dst=/pvextractor/extractor/mapping/OpenSfM \
     lubo1994/pv-hawk:latest \
-    bash
+    bash 
     
 This should start an interactive shell in the Docker container. Run the tests in that shell with
 

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -113,14 +113,15 @@ This ensures that scripts running inside the container (e.g. the `view_gps.py` s
 Now, open a new terminal window. Navigate to the root directory of the PV Hawk source code and start the Docker container with the command
 
 .. code-block:: console
-
+    
   sudo docker run -it \
     --ipc=host \
     --env="DISPLAY" \
     --gpus=all \
-    -v /tmp/.X11-unix:/tmp/.X11-unix:rw \
-    -v "$(pwd)":/pvextractor \
-    -v /storage:/storage \
+    --mount type=bind,src=/tmp/.X11-unix,dst=/tmp/.X11-unix:rw \
+    --mount type=bind,src="$(pwd)",dst=/pvextractor \
+    --mount type=volume,dst=/pvextractor/extractor/mapping/OpenSfM \
+    --mount type=bind,src=/storage,dst=/storage \
     -p "8888:8888" \
     lubo1994/pv-hawk:latest \
     bash
@@ -131,9 +132,9 @@ If you encounter an error message stating "Bind for 0.0.0.0:8888 failed: port is
 
 The `--gpus=all` option enables access of the GPU for Mask R-CNN inference. If you do not have a deep learning-capable GPU you can omit this option and PV Hawk will automatically fall back to using the CPU. 
 
-The options `--ipc=host`, `--env="DISPLAY"`, `-v /tmp/.X11-unix:/tmp/.X11-unix:rw` are required for graphical output of scripts running within the container. Just leave them untouched.
+The options `--ipc=host`, `--env="DISPLAY"`, `--mount type=bind,src=/tmp/.X11-unix,dst=/tmp/.X11-unix:rw` are required for graphical output of scripts running within the container. Just leave them untouched.
 
-The `-v "$(pwd)":/pvextractor` and `-v /storage:/storage` options map directories of your machine inside the Docker container. Mapping the `/storage` directory is needed to access our dataset from within the Docker container. If you placed your dataset at another location (e.g. at `/home/mydata`), please change the mapping accordingly (e.g. to `-v /home/mydata:/home/mydata`).
+The `--mount type=bind,src="$(pwd)",dst=/pvextractor` and `--mount type=bind,src=/storage,dst=/storage` options map directories of your machine inside the Docker container. Mapping the `/storage` directory is needed to access our dataset from within the Docker container. If you placed your dataset at another location (e.g. at `/home/mydata`), please change the mapping accordingly (e.g. to `--mount type=bind,src=/home/mydata,dst=/home/mydata`).
 
 .. note::
   It is important to launch the Docker container from the location of the PV Hawk source code. If you launch it from another location, the source code will not be available inside the container you will not be able to run PV Hawk.


### PR DESCRIPTION
Instead of mounting all source code into the container like this `-v "$(pwd)":/pvextractor`, we exclude the directory `/pvextractor/extractor/mapping/OpenSfM`. This prevents opensfm build artefacts from being overwritten.

Fixes https://github.com/LukasBommes/PV-Hawk/issues/16